### PR TITLE
fix(react-native): run pod install before ios build

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "ios": "(cd ios && pod install) && react-native run-ios",
     "start": "react-native start"
   },
   "dependencies": {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-samples/aws-sdk-js-tests/issues/62

*Description of changes:*
run pod install before ios build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
