### PR TITLE
fix(react-native): ignore require cycle warning

### DIFF
--- a/packages/react-native/App.js
+++ b/packages/react-native/App.js
@@ -9,6 +9,7 @@
 import React, {useState} from 'react';
 import {
   Button,
+  LogBox,
   SafeAreaView,
   StatusBar,
   StyleSheet,
@@ -21,6 +22,9 @@ import {Header, Colors} from 'react-native/Libraries/NewAppScreen';
 
 import {utils} from '@aws-sdk/test-utils';
 const {getV2BrowserResponse, getV3BrowserResponse} = utils;
+
+// Refs: https://github.com/facebook/metro/issues/287#issuecomment-738622439
+LogBox.ignoreLogs(['Require cycle: node_modules']);
 
 const App: () => React$Node = () => {
   const [v2Response, setV2Response] = useState('');


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-samples/aws-sdk-js-tests/issues/65

*Description of changes:*
Ignore require cycle warning as suggested in https://github.com/facebook/metro/issues/287
The warning will still be shown in the Terminal while debugging.

Verified that warning is not shown in Emulator while making JS SDK v3 calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
