### PR TITLE
fix: change branch references to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ reported the issue. Please try to include as much information as you can. Detail
 
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the _master_ branch.
+1. You are working against the latest source on the _main_ branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Code Sample for testing AWS JS SDK
 
 ## Example test for data returned by DynamoDB client:
 
-- Checkout master branch: `git checkout master`
+- Checkout main branch: `git checkout main`
 - Run `yarn` to install dependencies
 
 ### Node.js:

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -18,7 +18,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "MIT-0",
-  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/master/packages/node",
+  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/main/packages/node",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-samples/aws-sdk-js-tests.git",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -22,7 +22,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "MIT-0",
-  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/master/packages/react-native",
+  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/main/packages/react-native",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-samples/aws-sdk-js-tests.git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,7 +15,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "MIT-0",
-  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/master/packages/utils",
+  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/main/packages/utils",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-samples/aws-sdk-js-tests.git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "MIT-0",
-  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/master/packages/web",
+  "homepage": "https://github.com/aws-samples/aws-sdk-js-tests/tree/main/packages/web",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-samples/aws-sdk-js-tests.git",


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-2338

*Description of changes:*
The default branch was updated from `master` to `main` as per instructions in https://github.com/github/renaming#renaming-existing-branches

This PR updates the references of master to main in code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
