### PR TITLE
feat: use esm in all workspace packages

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,5 +23,6 @@
     "type": "git",
     "url": "https://github.com/aws-samples/aws-sdk-js-tests.git",
     "directory": "packages/node"
-  }
+  },
+  "type": "module"
 }

--- a/packages/node/src/index.js
+++ b/packages/node/src/index.js
@@ -1,9 +1,4 @@
-const {
-  config: { REGION },
-} = require("@aws-sdk/test-utils");
-const {
-  utils: { getV2Response, getV3Response },
-} = require("@aws-sdk/test-utils");
+import { REGION, getV2Response, getV3Response } from "@aws-sdk/test-utils";
 
 (async () => {
   let response;

--- a/packages/react-native/App.js
+++ b/packages/react-native/App.js
@@ -24,8 +24,7 @@ import {Header, Colors} from 'react-native/Libraries/NewAppScreen';
 import 'react-native-get-random-values';
 import 'react-native-url-polyfill/auto';
 
-import {utils} from '@aws-sdk/test-utils';
-const {getV2BrowserResponse, getV3BrowserResponse} = utils;
+import {getV2BrowserResponse, getV3BrowserResponse} from '@aws-sdk/test-utils';
 
 // Refs: https://github.com/facebook/metro/issues/287#issuecomment-738622439
 LogBox.ignoreLogs(['Require cycle: node_modules']);

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,5 +20,6 @@
     "type": "git",
     "url": "https://github.com/aws-samples/aws-sdk-js-tests.git",
     "directory": "packages/utils"
-  }
+  },
+  "type": "module"
 }

--- a/packages/utils/src/config.js
+++ b/packages/utils/src/config.js
@@ -1,4 +1,2 @@
-module.exports = {
-  REGION: "REGION",
-  IDENTITY_POOL_ID: "IDENTITY_POOL_ID",
-};
+export const REGION = "REGION";
+export const IDENTITY_POOL_ID = "IDENTITY_POOL_ID";

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,4 +1,2 @@
-module.exports = {
-  config: require("./config"),
-  utils: require("./utils"),
-};
+export * from "./config";
+export * from "./utils";

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,2 +1,2 @@
-export * from "./config";
-export * from "./utils";
+export * from "./config.js";
+export * from "./utils.js";

--- a/packages/utils/src/utils.js
+++ b/packages/utils/src/utils.js
@@ -4,19 +4,19 @@ import { fromCognitoIdentityPool } from "@aws-sdk/credential-provider-cognito-id
 import { CognitoIdentityClient } from "@aws-sdk/client-cognito-identity";
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
-import { REGION, IDENTITY_POOL_ID } from "./config";
+import { REGION, IDENTITY_POOL_ID } from "./config.js";
 
-const getV2Response = async (clientParams) => {
+export const getV2Response = async (clientParams) => {
   const client = new AWS.DynamoDB(clientParams);
   return client.listTables().promise();
 };
 
-const getV3Response = async (clientParams) => {
+export const getV3Response = async (clientParams) => {
   const client = new DynamoDB(clientParams);
   return client.listTables({});
 };
 
-const getV2BrowserResponse = async () => {
+export const getV2BrowserResponse = async () => {
   // Initialize the Amazon Cognito credentials provider
   AWS.config.region = REGION;
   AWS.config.credentials = new AWS.CognitoIdentityCredentials({
@@ -26,7 +26,7 @@ const getV2BrowserResponse = async () => {
   return getV2Response({ region: REGION });
 };
 
-const getV3BrowserResponse = async () =>
+export const getV3BrowserResponse = async () =>
   getV3Response({
     region: REGION,
     credentials: fromCognitoIdentityPool({
@@ -36,10 +36,3 @@ const getV3BrowserResponse = async () =>
       identityPoolId: IDENTITY_POOL_ID,
     }),
   });
-
-export default {
-  getV2Response,
-  getV3Response,
-  getV2BrowserResponse,
-  getV3BrowserResponse,
-};

--- a/packages/utils/src/utils.js
+++ b/packages/utils/src/utils.js
@@ -1,12 +1,10 @@
-const AWS = require("aws-sdk");
+import AWS from "aws-sdk";
 
-const {
-  fromCognitoIdentityPool,
-} = require("@aws-sdk/credential-provider-cognito-identity");
-const { CognitoIdentityClient } = require("@aws-sdk/client-cognito-identity");
-const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+import { fromCognitoIdentityPool } from "@aws-sdk/credential-provider-cognito-identity";
+import { CognitoIdentityClient } from "@aws-sdk/client-cognito-identity";
+import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
-const { REGION, IDENTITY_POOL_ID } = require("./config");
+import { REGION, IDENTITY_POOL_ID } from "./config";
 
 const getV2Response = async (clientParams) => {
   const client = new AWS.DynamoDB(clientParams);
@@ -39,7 +37,7 @@ const getV3BrowserResponse = async () =>
     }),
   });
 
-module.exports = {
+export default {
   getV2Response,
   getV3Response,
   getV2BrowserResponse,

--- a/packages/web/src/index.js
+++ b/packages/web/src/index.js
@@ -1,6 +1,7 @@
-const {
-  utils: { getV2BrowserResponse, getV3BrowserResponse },
-} = require("@aws-sdk/test-utils");
+import {
+  getV2BrowserResponse,
+  getV3BrowserResponse,
+} from "@aws-sdk/test-utils";
 
 const getHTMLElement = (title, content) => {
   const element = document.createElement("div");


### PR DESCRIPTION
*Issue #, if available:*
Required to use vite in https://github.com/aws-samples/aws-sdk-js-tests/pull/91
Node.js 10.x was EoL in [April 2021](https://github.com/nodejs/Release), and ESM modules are now supported in all LTS versions of Node.js

Refs: https://blog.sindresorhus.com/get-ready-for-esm-aa53530b3f77

*Description of changes:*
Use esm for all workspace packages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
