### PR TITLE
chore(deps-dev): bump tar to 6.1.11

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8109,8 +8109,8 @@ fsevents@~2.1.2:
   linkType: hard
 
 "tar@npm:^6.0.2, tar@npm:^6.1.0":
-  version: 6.1.6
-  resolution: "tar@npm:6.1.6"
+  version: 6.1.11
+  resolution: "tar@npm:6.1.11"
   dependencies:
     chownr: ^2.0.0
     fs-minipass: ^2.0.0
@@ -8118,7 +8118,7 @@ fsevents@~2.1.2:
     minizlib: ^2.1.1
     mkdirp: ^1.0.3
     yallist: ^4.0.0
-  checksum: 583f1165281746b4c48adee4ff7bab4895e73999eeda3c8d59779e47c29dc1dc714d832608a491fead4fd794bf9e0bd51b3d4a4fbad87f487a8b360321d70e8c
+  checksum: a04c07bb9e2d8f46776517d4618f2406fb977a74d914ad98b264fc3db0fe8224da5bec11e5f8902c5b9bcb8ace22d95fbe3c7b36b8593b7dfc8391a25898f32f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/

*Description of changes:*
bump tar to 6.1.11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
