### PR TITLE
chore(deps-dev): bump vite to v2.5.10

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,6 +23,6 @@
     "directory": "packages/web"
   },
   "devDependencies": {
-    "vite": "2.4.4"
+    "vite": "2.5.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,7 +653,7 @@ __metadata:
   dependencies:
     "@aws-sdk/test-utils": "workspace:*"
     util: 0.12.3
-    vite: 2.4.4
+    vite: 2.5.10
   languageName: unknown
   linkType: soft
 
@@ -3846,12 +3846,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.12.8":
-  version: 0.12.19
-  resolution: "esbuild@npm:0.12.19"
+"esbuild@npm:^0.12.17":
+  version: 0.12.29
+  resolution: "esbuild@npm:0.12.29"
   bin:
     esbuild: bin/esbuild
-  checksum: f6ba6b9ee0e114c24b222bf95f18f6742002c4462d8b74e779effd1244bae8af964452ad8f6d70120d8ddf311a3b8ccc5026fb8ff1d0ac1fda14ed6435e2f6b3
+  checksum: 06a6e84eff02899b45c7d4441199f7bbc824a9f5a2d0332bfe9873963751213c71bcb03b8db96babbc45ef31c140580ff64317ee7600983fc88b84c2d9788bbf
   languageName: node
   linkType: hard
 
@@ -8544,11 +8544,11 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"vite@npm:2.4.4":
-  version: 2.4.4
-  resolution: "vite@npm:2.4.4"
+"vite@npm:2.5.10":
+  version: 2.5.10
+  resolution: "vite@npm:2.5.10"
   dependencies:
-    esbuild: ^0.12.8
+    esbuild: ^0.12.17
     fsevents: ~2.3.2
     postcss: ^8.3.6
     resolve: ^1.20.0
@@ -8558,7 +8558,7 @@ fsevents@~2.1.2:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 075deeb5f915f2a0a2b2e90c6bcbe919b894b6004133e3280eb413dfb17aa1dd6b82aaf35451291f3ba572566f8948e62b32476ce39d5046eef6092106c80a8a
+  checksum: 08b7cb50bd7ba2f35b9df235a993a38ce8f2f737324f00d75439c120e28d9d7b92a98bb6db8d103745c905f85eb784a3188527a906793c667689e545ecbe77ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws-samples/aws-sdk-js-tests/issues/100

*Description of changes:*
Verified that `yarn:web` shows tables from DynamoDB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
