### PR TITLE
fix(react-native): watch root folder in metro config

### DIFF
--- a/packages/react-native/metro.config.js
+++ b/packages/react-native/metro.config.js
@@ -4,11 +4,7 @@
  *
  * @format
  */
-const fs = require('fs');
 const path = require('path');
-
-const workspaces = fs.readdirSync(path.resolve(__dirname, '../'));
-const currentWorkspace = path.basename(__dirname);
 
 module.exports = {
   projectRoot: __dirname,
@@ -28,7 +24,5 @@ module.exports = {
       },
     }),
   },
-  watchFolders: workspaces
-    .filter(f => f !== currentWorkspace)
-    .map(f => path.join(__dirname, '../', f)),
+  watchFolders: [path.resolve(__dirname, '..', '..')],
 };


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-samples/aws-sdk-js-tests/issues/113

*Description of changes:*
Watch root folder in metro config as discussed in https://github.com/yarnpkg/berry/issues/1767#issuecomment-680997100

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
