### PR TITLE
chore: enable renovate for security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,15 @@
+{
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "groupName": "everything",
+      "matchManagers": ["yarn"],
+      "matchPackagePatterns": ["*"],
+      "separateMajorMinor": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws-samples/aws-sdk-js-tests/issues/96

*Description of changes:*
Enables security updates in renovatebot by referring https://github.com/renovatebot/renovate/discussions/15490

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
