### PR TITLE
fix: enable renovate for vulnerability alerts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,8 @@
 {
-  "extends": ["config:base"],
   "packageRules": [
     {
-      "enabled": false,
-      "groupName": "everything",
-      "matchManagers": ["yarn"],
-      "matchPackagePatterns": ["*"],
-      "separateMajorMinor": false
+      "packagePatterns": ["*"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-samples/aws-sdk-js-tests/issues/118

*Description of changes:*
Enables renovate bot for vulnerability alerts from https://github.com/renovatebot/config-help/issues/138#issuecomment-453886711

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
