### PR TITLE
chore(renovate): update deprecated packagePatterns config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "packageRules": [
     {
-      "packagePatterns": ["*"],
+      "matchPackagePatterns": ["*"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/renovatebot/renovate/pull/6939

*Description of changes:*
Renames packagePatterns to matchPackagePatterns in renovate config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
