### PR TITLE
chore(renovate): enable lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
@@ -6,6 +8,9 @@
     }
   ],
   "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
     "enabled": true
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/renovatebot/renovate/discussions/16435#discussioncomment-3175814

*Description of changes:*
Renovate does not open security PRs for transitive dependencies other than for npm lockfile version 1.
This PR enables `lockFileMaintenance` configuration, so that lockfiles are updated once a week.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
