### PR TITLE
chore(renovate): enable dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", ":dependencyDashboard"],
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/renovatebot/config-help/issues/814#issuecomment-675843255

*Description of changes:*
For Renovate bot hosted as an GitHub App, a way to manually force dependency check is to enable [dependency dashboard](https://docs.renovatebot.com/key-concepts/dashboard/). We enable the dashboard in this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
