### PR TITLE
chore(renovate): set monthly schedule for lockFileMaintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
     "enabled": true
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": ["first day of the month"]
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws-samples/aws-sdk-js-tests/issues/122

*Description of changes:*
Sets lockfile maintenance to be once a month.
In case of security vulnerabilities, the PR can be created using Dependency Dashboard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
