### PR TITLE
fix(renovate): prefix every month in schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,6 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["first day of the month"]
+    "schedule": ["every month on the first day of the month"]
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-samples/aws-sdk-js-tests/issues/118

*Description of changes:*
Prefix every month in lockFileMaintenance schedule.
Schedule presets: https://docs.renovatebot.com/presets-schedule/#schedulemonthly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
