### PR TITLE
chore(deps): bump aws-sdk dependencies

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "main": "src/index.js",
   "dependencies": {
-    "@aws-sdk/client-cognito-identity": "3.150.0",
-    "@aws-sdk/client-dynamodb": "3.153.0",
-    "@aws-sdk/credential-provider-cognito-identity": "3.150.0",
-    "aws-sdk": "2.1198.0"
+    "@aws-sdk/client-cognito-identity": "3.200.0",
+    "@aws-sdk/client-dynamodb": "3.200.0",
+    "@aws-sdk/credential-provider-cognito-identity": "3.200.0",
+    "aws-sdk": "2.1244.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,589 +82,614 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/abort-controller@npm:3.127.0"
+"@aws-sdk/abort-controller@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/abort-controller@npm:3.200.0"
   dependencies:
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 9768573f8788db6fbed2a72a431860f6edb70a0795b78f2400993f91f471ad543e61eaca7503be949052af4ca953b23cc9b11e8bed5a3735198b65701349d759
+  checksum: 1104de705ad57c524fa451e7664998700df2e565d9c330e8d7cb9fb667f4841c14d97304ed288208719d70f5af1cbb28bef1edf4dac90737a87dfd92ecf390bf
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-cognito-identity@npm:3.150.0":
-  version: 3.150.0
-  resolution: "@aws-sdk/client-cognito-identity@npm:3.150.0"
+"@aws-sdk/client-cognito-identity@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/client-cognito-identity@npm:3.200.0"
   dependencies:
     "@aws-crypto/sha256-browser": 2.0.0
     "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/client-sts": 3.150.0
-    "@aws-sdk/config-resolver": 3.130.0
-    "@aws-sdk/credential-provider-node": 3.150.0
-    "@aws-sdk/fetch-http-handler": 3.131.0
-    "@aws-sdk/hash-node": 3.127.0
-    "@aws-sdk/invalid-dependency": 3.127.0
-    "@aws-sdk/middleware-content-length": 3.127.0
-    "@aws-sdk/middleware-host-header": 3.127.0
-    "@aws-sdk/middleware-logger": 3.127.0
-    "@aws-sdk/middleware-recursion-detection": 3.127.0
-    "@aws-sdk/middleware-retry": 3.127.0
-    "@aws-sdk/middleware-serde": 3.127.0
-    "@aws-sdk/middleware-signing": 3.130.0
-    "@aws-sdk/middleware-stack": 3.127.0
-    "@aws-sdk/middleware-user-agent": 3.127.0
-    "@aws-sdk/node-config-provider": 3.127.0
-    "@aws-sdk/node-http-handler": 3.127.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/smithy-client": 3.142.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/url-parser": 3.127.0
-    "@aws-sdk/util-base64-browser": 3.109.0
-    "@aws-sdk/util-base64-node": 3.55.0
-    "@aws-sdk/util-body-length-browser": 3.55.0
-    "@aws-sdk/util-body-length-node": 3.55.0
-    "@aws-sdk/util-defaults-mode-browser": 3.142.0
-    "@aws-sdk/util-defaults-mode-node": 3.142.0
-    "@aws-sdk/util-user-agent-browser": 3.127.0
-    "@aws-sdk/util-user-agent-node": 3.127.0
-    "@aws-sdk/util-utf8-browser": 3.109.0
-    "@aws-sdk/util-utf8-node": 3.109.0
+    "@aws-sdk/client-sts": 3.200.0
+    "@aws-sdk/config-resolver": 3.200.0
+    "@aws-sdk/credential-provider-node": 3.200.0
+    "@aws-sdk/fetch-http-handler": 3.200.0
+    "@aws-sdk/hash-node": 3.200.0
+    "@aws-sdk/invalid-dependency": 3.200.0
+    "@aws-sdk/middleware-content-length": 3.200.0
+    "@aws-sdk/middleware-endpoint": 3.200.0
+    "@aws-sdk/middleware-host-header": 3.200.0
+    "@aws-sdk/middleware-logger": 3.200.0
+    "@aws-sdk/middleware-recursion-detection": 3.200.0
+    "@aws-sdk/middleware-retry": 3.200.0
+    "@aws-sdk/middleware-serde": 3.200.0
+    "@aws-sdk/middleware-signing": 3.200.0
+    "@aws-sdk/middleware-stack": 3.200.0
+    "@aws-sdk/middleware-user-agent": 3.200.0
+    "@aws-sdk/node-config-provider": 3.200.0
+    "@aws-sdk/node-http-handler": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/smithy-client": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/url-parser": 3.200.0
+    "@aws-sdk/util-base64-browser": 3.188.0
+    "@aws-sdk/util-base64-node": 3.188.0
+    "@aws-sdk/util-body-length-browser": 3.188.0
+    "@aws-sdk/util-body-length-node": 3.188.0
+    "@aws-sdk/util-defaults-mode-browser": 3.200.0
+    "@aws-sdk/util-defaults-mode-node": 3.200.0
+    "@aws-sdk/util-endpoints": 3.200.0
+    "@aws-sdk/util-user-agent-browser": 3.200.0
+    "@aws-sdk/util-user-agent-node": 3.200.0
+    "@aws-sdk/util-utf8-browser": 3.188.0
+    "@aws-sdk/util-utf8-node": 3.199.0
     tslib: ^2.3.1
-  checksum: 17c1f38a27f26ba9433e77ab8b7db8bd97d11240bec5243cc6a76af0c7924ad88249b9b6c55d352342f4133841f593c47661728745a9ef8f10db9eb91adfa2ea
+  checksum: 8ddb9fb32c61259a4c7dc44f7b5f21c86992d11836930c7ff1984e2e6c8c7b851a2063d8c3f4d1a55a837fc1225317f7a0abf6f204fb376e690b7f5db6b8fb9c
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-dynamodb@npm:3.153.0":
-  version: 3.153.0
-  resolution: "@aws-sdk/client-dynamodb@npm:3.153.0"
+"@aws-sdk/client-dynamodb@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/client-dynamodb@npm:3.200.0"
   dependencies:
     "@aws-crypto/sha256-browser": 2.0.0
     "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/client-sts": 3.150.0
-    "@aws-sdk/config-resolver": 3.130.0
-    "@aws-sdk/credential-provider-node": 3.150.0
-    "@aws-sdk/fetch-http-handler": 3.131.0
-    "@aws-sdk/hash-node": 3.127.0
-    "@aws-sdk/invalid-dependency": 3.127.0
-    "@aws-sdk/middleware-content-length": 3.127.0
-    "@aws-sdk/middleware-endpoint-discovery": 3.130.0
-    "@aws-sdk/middleware-host-header": 3.127.0
-    "@aws-sdk/middleware-logger": 3.127.0
-    "@aws-sdk/middleware-recursion-detection": 3.127.0
-    "@aws-sdk/middleware-retry": 3.127.0
-    "@aws-sdk/middleware-serde": 3.127.0
-    "@aws-sdk/middleware-signing": 3.130.0
-    "@aws-sdk/middleware-stack": 3.127.0
-    "@aws-sdk/middleware-user-agent": 3.127.0
-    "@aws-sdk/node-config-provider": 3.127.0
-    "@aws-sdk/node-http-handler": 3.127.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/smithy-client": 3.142.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/url-parser": 3.127.0
-    "@aws-sdk/util-base64-browser": 3.109.0
-    "@aws-sdk/util-base64-node": 3.55.0
-    "@aws-sdk/util-body-length-browser": 3.55.0
-    "@aws-sdk/util-body-length-node": 3.55.0
-    "@aws-sdk/util-defaults-mode-browser": 3.142.0
-    "@aws-sdk/util-defaults-mode-node": 3.142.0
-    "@aws-sdk/util-user-agent-browser": 3.127.0
-    "@aws-sdk/util-user-agent-node": 3.127.0
-    "@aws-sdk/util-utf8-browser": 3.109.0
-    "@aws-sdk/util-utf8-node": 3.109.0
-    "@aws-sdk/util-waiter": 3.127.0
+    "@aws-sdk/client-sts": 3.200.0
+    "@aws-sdk/config-resolver": 3.200.0
+    "@aws-sdk/credential-provider-node": 3.200.0
+    "@aws-sdk/fetch-http-handler": 3.200.0
+    "@aws-sdk/hash-node": 3.200.0
+    "@aws-sdk/invalid-dependency": 3.200.0
+    "@aws-sdk/middleware-content-length": 3.200.0
+    "@aws-sdk/middleware-endpoint": 3.200.0
+    "@aws-sdk/middleware-endpoint-discovery": 3.200.0
+    "@aws-sdk/middleware-host-header": 3.200.0
+    "@aws-sdk/middleware-logger": 3.200.0
+    "@aws-sdk/middleware-recursion-detection": 3.200.0
+    "@aws-sdk/middleware-retry": 3.200.0
+    "@aws-sdk/middleware-serde": 3.200.0
+    "@aws-sdk/middleware-signing": 3.200.0
+    "@aws-sdk/middleware-stack": 3.200.0
+    "@aws-sdk/middleware-user-agent": 3.200.0
+    "@aws-sdk/node-config-provider": 3.200.0
+    "@aws-sdk/node-http-handler": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/smithy-client": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/url-parser": 3.200.0
+    "@aws-sdk/util-base64-browser": 3.188.0
+    "@aws-sdk/util-base64-node": 3.188.0
+    "@aws-sdk/util-body-length-browser": 3.188.0
+    "@aws-sdk/util-body-length-node": 3.188.0
+    "@aws-sdk/util-defaults-mode-browser": 3.200.0
+    "@aws-sdk/util-defaults-mode-node": 3.200.0
+    "@aws-sdk/util-endpoints": 3.200.0
+    "@aws-sdk/util-user-agent-browser": 3.200.0
+    "@aws-sdk/util-user-agent-node": 3.200.0
+    "@aws-sdk/util-utf8-browser": 3.188.0
+    "@aws-sdk/util-utf8-node": 3.199.0
+    "@aws-sdk/util-waiter": 3.200.0
     tslib: ^2.3.1
     uuid: ^8.3.2
-  checksum: a6a5bee78fa8037af81aad27243a3fed4f6200e869aebfb010b7bee441b7abfa3154659dc93f1e1dce0d790496317a2f41908ebf19a00f1c012c26fe9118a97b
+  checksum: 9e2dbdd6759c90741d4b0d6f5061d6835963eeb77bfb71128193092e5c4300930560a0990a5574af01e46ddf8bcab646451b0e342fab5b710057f387cb15f2d8
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.150.0":
-  version: 3.150.0
-  resolution: "@aws-sdk/client-sso@npm:3.150.0"
+"@aws-sdk/client-sso@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/client-sso@npm:3.200.0"
   dependencies:
     "@aws-crypto/sha256-browser": 2.0.0
     "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.130.0
-    "@aws-sdk/fetch-http-handler": 3.131.0
-    "@aws-sdk/hash-node": 3.127.0
-    "@aws-sdk/invalid-dependency": 3.127.0
-    "@aws-sdk/middleware-content-length": 3.127.0
-    "@aws-sdk/middleware-host-header": 3.127.0
-    "@aws-sdk/middleware-logger": 3.127.0
-    "@aws-sdk/middleware-recursion-detection": 3.127.0
-    "@aws-sdk/middleware-retry": 3.127.0
-    "@aws-sdk/middleware-serde": 3.127.0
-    "@aws-sdk/middleware-stack": 3.127.0
-    "@aws-sdk/middleware-user-agent": 3.127.0
-    "@aws-sdk/node-config-provider": 3.127.0
-    "@aws-sdk/node-http-handler": 3.127.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/smithy-client": 3.142.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/url-parser": 3.127.0
-    "@aws-sdk/util-base64-browser": 3.109.0
-    "@aws-sdk/util-base64-node": 3.55.0
-    "@aws-sdk/util-body-length-browser": 3.55.0
-    "@aws-sdk/util-body-length-node": 3.55.0
-    "@aws-sdk/util-defaults-mode-browser": 3.142.0
-    "@aws-sdk/util-defaults-mode-node": 3.142.0
-    "@aws-sdk/util-user-agent-browser": 3.127.0
-    "@aws-sdk/util-user-agent-node": 3.127.0
-    "@aws-sdk/util-utf8-browser": 3.109.0
-    "@aws-sdk/util-utf8-node": 3.109.0
+    "@aws-sdk/config-resolver": 3.200.0
+    "@aws-sdk/fetch-http-handler": 3.200.0
+    "@aws-sdk/hash-node": 3.200.0
+    "@aws-sdk/invalid-dependency": 3.200.0
+    "@aws-sdk/middleware-content-length": 3.200.0
+    "@aws-sdk/middleware-endpoint": 3.200.0
+    "@aws-sdk/middleware-host-header": 3.200.0
+    "@aws-sdk/middleware-logger": 3.200.0
+    "@aws-sdk/middleware-recursion-detection": 3.200.0
+    "@aws-sdk/middleware-retry": 3.200.0
+    "@aws-sdk/middleware-serde": 3.200.0
+    "@aws-sdk/middleware-stack": 3.200.0
+    "@aws-sdk/middleware-user-agent": 3.200.0
+    "@aws-sdk/node-config-provider": 3.200.0
+    "@aws-sdk/node-http-handler": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/smithy-client": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/url-parser": 3.200.0
+    "@aws-sdk/util-base64-browser": 3.188.0
+    "@aws-sdk/util-base64-node": 3.188.0
+    "@aws-sdk/util-body-length-browser": 3.188.0
+    "@aws-sdk/util-body-length-node": 3.188.0
+    "@aws-sdk/util-defaults-mode-browser": 3.200.0
+    "@aws-sdk/util-defaults-mode-node": 3.200.0
+    "@aws-sdk/util-endpoints": 3.200.0
+    "@aws-sdk/util-user-agent-browser": 3.200.0
+    "@aws-sdk/util-user-agent-node": 3.200.0
+    "@aws-sdk/util-utf8-browser": 3.188.0
+    "@aws-sdk/util-utf8-node": 3.199.0
     tslib: ^2.3.1
-  checksum: cd896ba1e091dcd8e6ffded5221820074f59e47d461eb3eb106d988dbb975149dc515063f6dd1065a119fec047d6ae9c9c01f457fd5cab967860e569aa2cd2c4
+  checksum: 97ee58fefc4385a3de94d73bd84c90fd0626d586422063e8ac9cf88e0008e5fd979e5ad5157df0d62255c9ef22f5194fe3ff2d7ea316eb01848b8151cb9d23b6
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.150.0":
-  version: 3.150.0
-  resolution: "@aws-sdk/client-sts@npm:3.150.0"
+"@aws-sdk/client-sts@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/client-sts@npm:3.200.0"
   dependencies:
     "@aws-crypto/sha256-browser": 2.0.0
     "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.130.0
-    "@aws-sdk/credential-provider-node": 3.150.0
-    "@aws-sdk/fetch-http-handler": 3.131.0
-    "@aws-sdk/hash-node": 3.127.0
-    "@aws-sdk/invalid-dependency": 3.127.0
-    "@aws-sdk/middleware-content-length": 3.127.0
-    "@aws-sdk/middleware-host-header": 3.127.0
-    "@aws-sdk/middleware-logger": 3.127.0
-    "@aws-sdk/middleware-recursion-detection": 3.127.0
-    "@aws-sdk/middleware-retry": 3.127.0
-    "@aws-sdk/middleware-sdk-sts": 3.130.0
-    "@aws-sdk/middleware-serde": 3.127.0
-    "@aws-sdk/middleware-signing": 3.130.0
-    "@aws-sdk/middleware-stack": 3.127.0
-    "@aws-sdk/middleware-user-agent": 3.127.0
-    "@aws-sdk/node-config-provider": 3.127.0
-    "@aws-sdk/node-http-handler": 3.127.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/smithy-client": 3.142.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/url-parser": 3.127.0
-    "@aws-sdk/util-base64-browser": 3.109.0
-    "@aws-sdk/util-base64-node": 3.55.0
-    "@aws-sdk/util-body-length-browser": 3.55.0
-    "@aws-sdk/util-body-length-node": 3.55.0
-    "@aws-sdk/util-defaults-mode-browser": 3.142.0
-    "@aws-sdk/util-defaults-mode-node": 3.142.0
-    "@aws-sdk/util-user-agent-browser": 3.127.0
-    "@aws-sdk/util-user-agent-node": 3.127.0
-    "@aws-sdk/util-utf8-browser": 3.109.0
-    "@aws-sdk/util-utf8-node": 3.109.0
-    entities: 2.2.0
-    fast-xml-parser: 3.19.0
+    "@aws-sdk/config-resolver": 3.200.0
+    "@aws-sdk/credential-provider-node": 3.200.0
+    "@aws-sdk/fetch-http-handler": 3.200.0
+    "@aws-sdk/hash-node": 3.200.0
+    "@aws-sdk/invalid-dependency": 3.200.0
+    "@aws-sdk/middleware-content-length": 3.200.0
+    "@aws-sdk/middleware-endpoint": 3.200.0
+    "@aws-sdk/middleware-host-header": 3.200.0
+    "@aws-sdk/middleware-logger": 3.200.0
+    "@aws-sdk/middleware-recursion-detection": 3.200.0
+    "@aws-sdk/middleware-retry": 3.200.0
+    "@aws-sdk/middleware-sdk-sts": 3.200.0
+    "@aws-sdk/middleware-serde": 3.200.0
+    "@aws-sdk/middleware-signing": 3.200.0
+    "@aws-sdk/middleware-stack": 3.200.0
+    "@aws-sdk/middleware-user-agent": 3.200.0
+    "@aws-sdk/node-config-provider": 3.200.0
+    "@aws-sdk/node-http-handler": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/smithy-client": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/url-parser": 3.200.0
+    "@aws-sdk/util-base64-browser": 3.188.0
+    "@aws-sdk/util-base64-node": 3.188.0
+    "@aws-sdk/util-body-length-browser": 3.188.0
+    "@aws-sdk/util-body-length-node": 3.188.0
+    "@aws-sdk/util-defaults-mode-browser": 3.200.0
+    "@aws-sdk/util-defaults-mode-node": 3.200.0
+    "@aws-sdk/util-endpoints": 3.200.0
+    "@aws-sdk/util-user-agent-browser": 3.200.0
+    "@aws-sdk/util-user-agent-node": 3.200.0
+    "@aws-sdk/util-utf8-browser": 3.188.0
+    "@aws-sdk/util-utf8-node": 3.199.0
+    fast-xml-parser: 4.0.11
     tslib: ^2.3.1
-  checksum: 277703e5ea9f5c27b4e93f1e8c172efe1334bc21fec0dde16f831dfb90ac854b7070a489aa31e0ca3ad6bd7e583e1c6f1d20453323553e444ad413fcf5298f39
+  checksum: e32b92c0d8609fbe30e750e901ff585316be5fb42f3430c2b75096fab102707cb076453361ac21c488139043b78369c13e90ddcea886208efb5bfc712536d847
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.130.0":
-  version: 3.130.0
-  resolution: "@aws-sdk/config-resolver@npm:3.130.0"
+"@aws-sdk/config-resolver@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/config-resolver@npm:3.200.0"
   dependencies:
-    "@aws-sdk/signature-v4": 3.130.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/util-config-provider": 3.109.0
-    "@aws-sdk/util-middleware": 3.127.0
+    "@aws-sdk/signature-v4": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/util-config-provider": 3.188.0
+    "@aws-sdk/util-middleware": 3.200.0
     tslib: ^2.3.1
-  checksum: 33fa2be1c94fffa2a053a53a2db3402f02493cacade3aff65d70474d404d71c1825c35dd78a3d87f9434b0f4212437bc82f83f10ae7cebdcfcfb0891145ce1ce
+  checksum: 5446227a4f723117a3212b0fd4c03ce34da4dfca59403c8f23f511283c961d1c9635445001bf32e18404addc877a5d34bd74fb8e07edd073d7ac0e40f9fde174
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-cognito-identity@npm:3.150.0":
-  version: 3.150.0
-  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.150.0"
+"@aws-sdk/credential-provider-cognito-identity@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-cognito-identity@npm:3.200.0"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.150.0
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/client-cognito-identity": 3.200.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 2bbc33fd002f66616989ae76dafc37f2cae9e3e06cd7dcbd14ea472f1cb4b9420058e444475c316c818d72981ce45f5b0c6d3d130299840977f59510dfefcbf6
+  checksum: 701136d7a6b12eb6b4f71ab7cf10a69db6140a71a3136a92a6c95071222c3765d5dd3389db9ceeb5b736db84e96a995cb7b69ba13233cb8abb51672bad680ddd
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.127.0"
+"@aws-sdk/credential-provider-env@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.200.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: e4cc8bd53b67d07f9ff0b1eae9193e8a1bffdc167a49f09d96334476f6d165652a6ff68ba306c044d4ceeb84be4181104f1452d59ff75c7a284a6fde1516556b
+  checksum: 6dc4297d9b21f99251d1bf8301318ad43f8c6b00dabd613580141c20940ebe0d7aee06cebe425b24123c20524d09a258fcb5400c266983cba4dd772712e1c792
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-imds@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.127.0"
+"@aws-sdk/credential-provider-imds@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.200.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.127.0
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/url-parser": 3.127.0
+    "@aws-sdk/node-config-provider": 3.200.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/url-parser": 3.200.0
     tslib: ^2.3.1
-  checksum: f117bd18114cfee7f9a0201cc53244957f489b780ab5f57ef1c9896a9838688ffb9c7d3a4a6db366629aff2f7a99dab95a6b149130ccb0deab25f6fc04cd9edd
+  checksum: a97133b5ddce273ceb76d6125deac8d417e51a40c3bf588b0043b73a2c05e940fdac106df7b241ab05dd65fc95c34d7774e8f1c6a595dd71f9938a68f42231b7
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.150.0":
-  version: 3.150.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.150.0"
+"@aws-sdk/credential-provider-ini@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.200.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.127.0
-    "@aws-sdk/credential-provider-imds": 3.127.0
-    "@aws-sdk/credential-provider-sso": 3.150.0
-    "@aws-sdk/credential-provider-web-identity": 3.127.0
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/shared-ini-file-loader": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/credential-provider-env": 3.200.0
+    "@aws-sdk/credential-provider-imds": 3.200.0
+    "@aws-sdk/credential-provider-sso": 3.200.0
+    "@aws-sdk/credential-provider-web-identity": 3.200.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/shared-ini-file-loader": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 4aad8712bbc4a41aae0d6898cdb750a33dbf4e4f72e37970ca08b6a7134ebd37c619a56fd58505bad3ac183e424aa4b41386c46ac8c5bd34a5798c458b8850ec
+  checksum: 3a8629e93106826451bdd0c2d1e6f5ed063dfb2f260e2eec47efd385f5f51dda65f6c5bb14af24d7a0deec97d3b1de7a07fccf1a9f118c9982656a82483d4247
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.150.0":
-  version: 3.150.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.150.0"
+"@aws-sdk/credential-provider-node@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.200.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.127.0
-    "@aws-sdk/credential-provider-imds": 3.127.0
-    "@aws-sdk/credential-provider-ini": 3.150.0
-    "@aws-sdk/credential-provider-process": 3.127.0
-    "@aws-sdk/credential-provider-sso": 3.150.0
-    "@aws-sdk/credential-provider-web-identity": 3.127.0
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/shared-ini-file-loader": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/credential-provider-env": 3.200.0
+    "@aws-sdk/credential-provider-imds": 3.200.0
+    "@aws-sdk/credential-provider-ini": 3.200.0
+    "@aws-sdk/credential-provider-process": 3.200.0
+    "@aws-sdk/credential-provider-sso": 3.200.0
+    "@aws-sdk/credential-provider-web-identity": 3.200.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/shared-ini-file-loader": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: ee84774e0439550cd07a4415563657123c9a2e2e491df9ab76cb510e6ebc6fba095f9cdb23603bc0813a3fd9ce4f855e75e026feef6fad509706bc780d1aeffa
+  checksum: 88bd9405afe722857a457b0b3e5379994c9a8f435ef69c4f3e254d296d4f651ab3f9357f00ad4bc373342c7b7b5090328236f1d93a72e75d6b916f0c7d36d55a
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.127.0"
+"@aws-sdk/credential-provider-process@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.200.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/shared-ini-file-loader": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/shared-ini-file-loader": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 60becf9f7d939c11a7b8aa8b6116c37f7d8069d1049a39404ca1f839771c6da4226e58a0acea3830ec591df3949fe5c703b9cd11e42a4f0b6d4cc54c8b4127dd
+  checksum: 91c2e557c5a2232903e8d3f4f1983b036158564a5f971a5e7c18a075162b11c406217d8e17378966c37a8e19da409b81ab5f548e6b6eacbb9e01c8212c5a2c07
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.150.0":
-  version: 3.150.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.150.0"
+"@aws-sdk/credential-provider-sso@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.200.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.150.0
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/shared-ini-file-loader": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/client-sso": 3.200.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/shared-ini-file-loader": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 7887530dcc7a8b796b1bac6822b44be9490e9e755afa64003be744e16c7806ca3bb31e6729dd0b923d98d9967b89ba98b31a928c07c1f7f362791ae1351fada8
+  checksum: d03bede52c2a278f3aa0fe87e136d7c385dfe09a7769c2aca9e721ee0e6ba12969009c194f4a4d4c22304fa464bff79a618d5bc3bb7e06adc344df59f73b175b
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.127.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.200.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 359bc73eff0593e77e969a5e6506fedd93bd9e32f01043e044a5813dc445f7a5886bfac2676cabfc5c8a913dfc9c71e77fc68dfdd86ec5f1c293a342b42a13ee
+  checksum: dac2fdc8ec3862fddcdc367e7b03602027e0fafbfa374aca3b60a03cbae9e56d5da5071697089984f97bd489dc43db42e2592763191032166a71bc83785f583a
   languageName: node
   linkType: hard
 
-"@aws-sdk/endpoint-cache@npm:3.55.0":
-  version: 3.55.0
-  resolution: "@aws-sdk/endpoint-cache@npm:3.55.0"
+"@aws-sdk/endpoint-cache@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/endpoint-cache@npm:3.188.0"
   dependencies:
     mnemonist: 0.38.3
     tslib: ^2.3.1
-  checksum: 562f0ebaca1717010a23bca507a1118afd191a7a2eb87fb2d331361180f2f98f8ba3d0955f0a90fc2ff72e2b5832bb03577ea52cb9c5699ee28df1abc30c5b6a
+  checksum: 9d8255f361f8c457f8a3738db4e466504bbfae07f4fa8f89da3070622fd5b41eb02d6ce824d16838bff5100325e1353d821149c00e4b694438d590a0736579ed
   languageName: node
   linkType: hard
 
-"@aws-sdk/fetch-http-handler@npm:3.131.0":
-  version: 3.131.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.131.0"
+"@aws-sdk/fetch-http-handler@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.200.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/querystring-builder": 3.127.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/querystring-builder": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/util-base64-browser": 3.188.0
     tslib: ^2.3.1
-  checksum: 7bd5a83b929e59b86058c7a834daa8eedc7eab7a6bdb2016ff8898637c28bf7062830b108a45d70890062aa0f15271501290c18b06926a8af1bcb8d181817600
+  checksum: 6bad7692c6f6ebbd335ebba8208e75ed93928a686731b2bfb80cab743e19f14cc20bc4a8be88553ac47537866ee8a38e8f154a2cdd3acc8053d9d2069c3604b4
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-node@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/hash-node@npm:3.127.0"
+"@aws-sdk/hash-node@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/hash-node@npm:3.200.0"
   dependencies:
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/util-buffer-from": 3.55.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/util-buffer-from": 3.188.0
     tslib: ^2.3.1
-  checksum: fb07d9cd29cae316a1a4c0cd448489d6e14bd386fa49b08832d015c8bbcc59cad94e21fdd2f74f8dab08e0c01e1e0cddeac47f48d89dc766d10e95a0a62e7a23
+  checksum: 1ca743ba04511aabd12b113ae12662209dbaeb0ba389e4b4a6e197ecaf598debd271c855f08c0e054369514c1ffe8912108ba97ea2a7188f66c921caac3c1600
   languageName: node
   linkType: hard
 
-"@aws-sdk/invalid-dependency@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.127.0"
+"@aws-sdk/invalid-dependency@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.200.0"
   dependencies:
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 456b675fd05716050d2dfc325f92918cbd5bbd11c90096673eb7bc66f61ef55021459e893839b8b62ac09ee320ef77924c30cb25530fa1c74b848f3989695fbd
+  checksum: 2e1eb1b95da6776264b9292944e77c2f67627dd522178d2b424c0fd8a516e7506d1b2e89003450d8070d2d0c08cbca13c8672a15caa8cfc1f59ce2da9bc816c7
   languageName: node
   linkType: hard
 
-"@aws-sdk/is-array-buffer@npm:3.55.0":
-  version: 3.55.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.55.0"
+"@aws-sdk/is-array-buffer@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/is-array-buffer@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: 527481f024166197b84a2b4859b51df9b6da4396255c19832e8fdb2f6dfc914dab8ad89433602f8d797f3f8dacc312ab8a0073b2c8e20dc85a28ad9d27aceaa7
+  checksum: be98f3936241cae66d2ab399d4e3b1b91a530b5abc7c6e35faa110b26aad923343004492e8b305030fa81d7d64bcba7066a5c0e2e5ec3a814719bfc2b2fa00b1
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-content-length@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.127.0"
+"@aws-sdk/middleware-content-length@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.200.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 817f74342e862bb10e871d09cf937d7bb7eb5189b2ec4b8ce7b0657c38c74b5d0b6be8143f6618e037c5a29bef624446dfd5fe0cc0ce8114d87d5eded4778074
+  checksum: aa2ce4a28d0f1847d1910aa89c9d1245d94b5ea0e5fb7973950e4fbe3dfc6edae6106e05658bdc21eff33c30b0df41c28b06862069f676d9f0dcda16c11ed0c1
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-endpoint-discovery@npm:3.130.0":
-  version: 3.130.0
-  resolution: "@aws-sdk/middleware-endpoint-discovery@npm:3.130.0"
+"@aws-sdk/middleware-endpoint-discovery@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-endpoint-discovery@npm:3.200.0"
   dependencies:
-    "@aws-sdk/config-resolver": 3.130.0
-    "@aws-sdk/endpoint-cache": 3.55.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/config-resolver": 3.200.0
+    "@aws-sdk/endpoint-cache": 3.188.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: c506e4630fb4051b93a9c7599fda17de27b27cdb104485e4cff5bb096e5a38063d203844973aad29c2353a10aa8615b362072d64923b50656c11d00f2e9c9f84
+  checksum: c297a141484a2958934a6452f7e16268a14ab535280de4cd862814a19f855d7e3aa5ceb3b7222bede6b0d3d06027b50205ddd96f0bbd95ee360a88b9a5b6e1d3
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.127.0"
+"@aws-sdk/middleware-endpoint@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-endpoint@npm:3.200.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/middleware-serde": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/signature-v4": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/url-parser": 3.200.0
+    "@aws-sdk/util-config-provider": 3.188.0
+    "@aws-sdk/util-middleware": 3.200.0
     tslib: ^2.3.1
-  checksum: 8ec8a7f7b260c6f3608ba6500586aefd024ac859baaccca9cbea73dfa43fc95cf3a123e369798c6bbd36ed7f3eb36482b5b2a41f46b0eb1416f94d6829e92e9f
+  checksum: c319025b6c46d73ebd4ae927b3789ecbacd5b65510bbabb1289e20e1b935760592a37fb33249f90958c751839327ba9979cc66553389692461ea7691b5ff63bc
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.127.0"
+"@aws-sdk/middleware-host-header@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.200.0"
   dependencies:
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: edc37f262bdab27bd0d1e26ed1ec1656d8257e9b9db58f45ccd0eb9ff9a39f71deb43955a843d440adce73a608a499ce7478780b774b5fb057bc4769dd7ee27d
+  checksum: 3d751c545b6782d06ad052fcbe77c3af22bf0bfcae70d90d5fb9c03d7676611866ce1f2ee7b6b1d14740873538a322c048bd4ee9f8bdf29fcf58998a9168d4f8
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-recursion-detection@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.127.0"
+"@aws-sdk/middleware-logger@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.200.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: dd04f307c4501bc35fef048a748a5d668061725b10d7cc39143404773049687957fa046b406677ce625279c1d2161cba17b0c639cb59579fc091abd06b91a719
+  checksum: 0cd27b998c15977e70dd22d17f5023c4048c513614c08675cbeea598d598af633744e331546617b93ef4d4ef7074d944cb8aede3e05e1e22b03f254d8c33b031
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-retry@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.127.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.200.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/service-error-classification": 3.127.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/util-middleware": 3.127.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: c92124515a8ceee1dae25e9bd39cf738df5d9e5764ac99fe329e09591c10ad9cd3248694375873a292ccaf1d93d2a17ebc54461102af70f1ce698050ea6149c2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-retry@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/service-error-classification": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/util-middleware": 3.200.0
     tslib: ^2.3.1
     uuid: ^8.3.2
-  checksum: 314800be7d2cc1f20314ae413c029f31ef47ffc35a0a555944c87ea278ab61dafdf63cdf339effae9de66cbde542f0e25c8c8b3acf2c0d6a9cfbe59b09f646af
+  checksum: c038a538e168a357526c7635ac41b49091a2673d7be553a9ac37358a95063de11cb80b51a3596fb3cb933fa9529f19cf09e914a361cb134eb1cf6194d685e67b
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.130.0":
-  version: 3.130.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.130.0"
+"@aws-sdk/middleware-sdk-sts@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.200.0"
   dependencies:
-    "@aws-sdk/middleware-signing": 3.130.0
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/signature-v4": 3.130.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/middleware-signing": 3.200.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/signature-v4": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 4c83eb02d9b8f0b18d9d24704e660463d9d15cc7881c231a1ad315681e5bdd67f70d413f00ddedbcd8c5ed337df317fa6ce366e5314b4a440269bd44c0fad514
+  checksum: 9452bbb7f1f76a9f19a43971a676059a20792aabc6745ea3ef4800476aa1bf52a5c5d2268ac268f78269de18aa8d116a7bc10561ed93d2265a7e92d269f93e3b
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-serde@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.127.0"
+"@aws-sdk/middleware-serde@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.200.0"
   dependencies:
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: ff31988f06ef1b1d006ec4231d7dd8e72d60ba43d599952c504a9657308a7a0a7ef0d5610a5e73c58f66b8b168db1235c61d9276a1ef59b7ce9227d3e9eff026
+  checksum: d968bfe5270d46542b767fdb2187abf38c57cd720a9d8d83299bf26905adad8b00f0fcfeb3b3fd684024bf742f8ebfec2cb19ab7fda3da948b5fdd6636dbc250
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.130.0":
-  version: 3.130.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.130.0"
+"@aws-sdk/middleware-signing@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.200.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/signature-v4": 3.130.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/signature-v4": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/util-middleware": 3.200.0
     tslib: ^2.3.1
-  checksum: 74e4e480a027967cb9b0e060246e98b5d134bcc5509619b57247196337e19ae31273086a9c00bedfcab22982d5d583568b99343e7f3ea7cb5b99a8dbb89c2cde
+  checksum: 8f4f0ebd28309f8fc408bef967cfe2eef79792ffbfd31a70524d5d0a59a450f6e5dbf4ef7524f493f89c721195e6e749feca0c4b207c7bca186b885750ab44db
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-stack@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.127.0"
-  dependencies:
-    tslib: ^2.3.1
-  checksum: 145a44b74681590edc328bb128a8f17af2b13b3e3a0c3bd8803636bafee4370db385fdc132d20ec2b0b331f849a367cb9b8b5ec37b4a705b70156c184ca9f84c
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/middleware-user-agent@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.127.0"
-  dependencies:
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/types": 3.127.0
-    tslib: ^2.3.1
-  checksum: 2967bc7fce3f4e2ec35ee650c4fad897a4bc454884ada00031a302bfdf6d53153332e5171cc760defad2bcd7acadf6549a398bf606674f642573f2786c3741e0
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-config-provider@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.127.0"
-  dependencies:
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/shared-ini-file-loader": 3.127.0
-    "@aws-sdk/types": 3.127.0
-    tslib: ^2.3.1
-  checksum: 733a40d93a45258c8c94702c0c5fcd829c2fcc6e3ec4c3e4d63b77ee1b01ee6591b49216b9acd80388de238603ab0a92dd0e7a09b09c654997873e574e95e4d2
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/node-http-handler@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.127.0"
-  dependencies:
-    "@aws-sdk/abort-controller": 3.127.0
-    "@aws-sdk/protocol-http": 3.127.0
-    "@aws-sdk/querystring-builder": 3.127.0
-    "@aws-sdk/types": 3.127.0
-    tslib: ^2.3.1
-  checksum: 55629edb90766ab5e62db4cd3a57751d719ddf79a1ebd9a8221fc9289509589535859337726b8ea942b96bcb356881ac1fc59707b9873270bde36da870092fab
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/property-provider@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/property-provider@npm:3.127.0"
-  dependencies:
-    "@aws-sdk/types": 3.127.0
-    tslib: ^2.3.1
-  checksum: e78770762fb0d5d904c0d270266cb9ef580184c0aee25d1df389bff3e66f6c4cfa2c99104488539d22fa642c6102027772b85b42a07c2a90306b0c4751a81698
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/protocol-http@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/protocol-http@npm:3.127.0"
-  dependencies:
-    "@aws-sdk/types": 3.127.0
-    tslib: ^2.3.1
-  checksum: 2d34deb09bd1ba4316945f441f75600aa621d8fa9021c92a91582ac299d857a64572eeb87f7306e3a06c899635dccc717e1353aa290d38665be97487b13038ee
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-builder@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.127.0"
-  dependencies:
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/util-uri-escape": 3.55.0
-    tslib: ^2.3.1
-  checksum: ac84867b038c530821987db9fac8aaab20dd4b0d0c9fe78caee2f5dd4e8d5b6a99b8cb7ea7816476b9b13149305aea46a2c176130b586882243a82478de35473
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/querystring-parser@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.127.0"
-  dependencies:
-    "@aws-sdk/types": 3.127.0
-    tslib: ^2.3.1
-  checksum: 1dcb87be1586e21cc4d98653211ab1d4f484c9a8d62be0acfbd8dde3629559e079e3ca67eb20ce6bc17a53262d5d3462eb3d701573380ea216a2dd77088cd2a5
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/service-error-classification@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.127.0"
-  checksum: dcc743ac7a480edf56eac3861d575819edd5f181f67e603c4f6cc2291ae1f88c116dc2cab19da172a1f7dc5f62195875483c5105ac2f4076ba6caf518ab3867d
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/shared-ini-file-loader@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.127.0"
+"@aws-sdk/middleware-stack@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.200.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: fa0c8ffa5d42940778b14e8f1d8998605b5d7ea43f3c19cc9dbb02f2d552c35dabc5850a5e6d3f6af68978b2171aaec435c05c648a1ecf1c2fb81fe9a60d9702
+  checksum: 6f1c72b3448fe7e7cb49e8041d454e1da1d13950b4c2536c6a8b690a7d1276279743ac987f5929f141afa50ad2d80f48a3f81093f8fe6a63f73bff7bf1df1da5
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4@npm:3.130.0":
-  version: 3.130.0
-  resolution: "@aws-sdk/signature-v4@npm:3.130.0"
+"@aws-sdk/middleware-user-agent@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.200.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.55.0
-    "@aws-sdk/types": 3.127.0
-    "@aws-sdk/util-hex-encoding": 3.109.0
-    "@aws-sdk/util-middleware": 3.127.0
-    "@aws-sdk/util-uri-escape": 3.55.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 10c63fa18db144eda63727006e812b1cd504b49e5c345c94ce45a0b4b072b82f1e5ca964468868a5351b0e795f1b2945bc2f4ef81a9fa2bad26485226958c33d
+  checksum: 3d55d9e599be9821157978f9082163639ebcd622425b39f4ba7f3b2326eb7e077fad52793c9fa7d617a94e1cee2feb2d86289e3c7bdf1c0018fe9fbc94dbab71
   languageName: node
   linkType: hard
 
-"@aws-sdk/smithy-client@npm:3.142.0":
-  version: 3.142.0
-  resolution: "@aws-sdk/smithy-client@npm:3.142.0"
+"@aws-sdk/node-config-provider@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.200.0"
   dependencies:
-    "@aws-sdk/middleware-stack": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/shared-ini-file-loader": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: e87b04dc11b935ba6ae30d894f28cfb93894d96f19bfaa9f8656cdad85d6daf68f8067493a228e9dc4eee4fc91672254287ce2f37740d895d89806c151785280
+  checksum: aa1a70ad8553bac7c9015263c09d94ab29632cd7aed52ab6d041e90d74b11644c04c65710439dfc93e3c44ad036d75291d931dfebb3f654ccb4611c8044069e4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-http-handler@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.200.0
+    "@aws-sdk/protocol-http": 3.200.0
+    "@aws-sdk/querystring-builder": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: 2a7a9291834b3c16baf814d6086065ebd4f0e4733eb9465ac807105cfa20a8d474fa3d89f2d87a2e7b945e7a0a38199af8e0395286f50b5f96ddc40a00bfa524
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/property-provider@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/property-provider@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: fec6971aad6c3eda8ae9e7fcf7fa9a178a67f2b6e4d8ab021be1bb0c80513b420fdd997591a1d660c4ec66706893eaa66461a089cd172aaa4eb2bc8833ad5355
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/protocol-http@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/protocol-http@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: b98d68195cc90f45bfb85bc1adaed0844bfac17985dc27e4f4bce2c807cf0b1b52b1daf70b28bcace9347f5c1fa9052a66d91a735e390ab7424c87cbb335bf57
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-builder@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/util-uri-escape": 3.188.0
+    tslib: ^2.3.1
+  checksum: fe9897035d14eb6db5b40a6ac519f5e52cfaf0e8b47c931099876d19b1fd68ac1544134cc97bc364ea3faacfc70e24019e845dcdea15d9c96dff478fbfb29516
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-parser@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: 1a20a1df1aa7a804aa7315153145f2b1d61e742f08dcf77be2fb5946206d321606931b8569ee16fe6d1960ec67881faac53beef26b3308796ab27b6dc82f43cb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/service-error-classification@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.200.0"
+  checksum: 41f468129b0cc3839dd8bfce0b8032b8966f8a8b5a8f924bdab204117cf3cc112d16732a5809c624bcec755154918d34789e1493938d5c77845f9f8dc44c97b7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/shared-ini-file-loader@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: 0090cee6ed22c1f69dc51b1e5cc3645fc77c2fe58887e03f4a334815ca27411025a6d4daf750a34340216b900374691bf9b633a4222b60acd0d859946781c8aa
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/signature-v4@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.188.0
+    "@aws-sdk/types": 3.200.0
+    "@aws-sdk/util-hex-encoding": 3.188.0
+    "@aws-sdk/util-middleware": 3.200.0
+    "@aws-sdk/util-uri-escape": 3.188.0
+    tslib: ^2.3.1
+  checksum: dcc3b7386d5b13f409c750f46760036e19796b98b84700d9fee4f0853e2db02a1ebcb12efd6b272c77409758c7d9412070f8c3c2c647709ccd78095303746527
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/smithy-client@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/smithy-client@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/middleware-stack": 3.200.0
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: ca9f4e5e888982099be526daa3a3b9db485ec33bd6da7876f837c484c24bb7017dfbcf924be1c8febb95b5f4098f2f0c6c42c4824527854fa89e77318ee86a37
   languageName: node
   linkType: hard
 
@@ -696,10 +721,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aws-sdk/test-utils@workspace:packages/utils"
   dependencies:
-    "@aws-sdk/client-cognito-identity": 3.150.0
-    "@aws-sdk/client-dynamodb": 3.153.0
-    "@aws-sdk/credential-provider-cognito-identity": 3.150.0
-    aws-sdk: 2.1198.0
+    "@aws-sdk/client-cognito-identity": 3.200.0
+    "@aws-sdk/client-dynamodb": 3.200.0
+    "@aws-sdk/credential-provider-cognito-identity": 3.200.0
+    aws-sdk: 2.1244.0
   languageName: unknown
   linkType: soft
 
@@ -722,10 +747,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aws-sdk/types@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/types@npm:3.127.0"
-  checksum: 35467177421fb180ca73eb85a327c814e3aaee11a8eabbf9f048d58ec4133d7205400ce2e3c3ef70d78a64a2359f1df2926e1a0e6f169a415c2896ff6dfb66d9
+"@aws-sdk/types@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/types@npm:3.200.0"
+  checksum: 4d35964d7876173ba1249ac15f528946c774c75a2e3a2b8edf0af7c23aebba5ad3723a16a12de989d5c0b89e73ce1dffaa9d2e73a66f67f553fa489eea90a5ac
   languageName: node
   linkType: hard
 
@@ -736,105 +761,115 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/url-parser@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/url-parser@npm:3.127.0"
+"@aws-sdk/url-parser@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/url-parser@npm:3.200.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/querystring-parser": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 5732f51d6fef2d26599cb186e230cd8e99c567f6efd7b3f27dc0ecdb660510a20a3384f00c5edb08d0e8e59fe3bcb5b8e368558aefbff2cf5201eaeb7caefa4a
+  checksum: 9823c33fe0b2a55e7e9cfde6674909625163811915019b61cc7b6536f80e6403d766649777ba72f2d5e81a8dbb30a94a7015223515b49f64e99fe2b1cbe4bfc5
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-browser@npm:3.109.0":
-  version: 3.109.0
-  resolution: "@aws-sdk/util-base64-browser@npm:3.109.0"
+"@aws-sdk/util-base64-browser@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-base64-browser@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: e4fb1dc0e5ac60320d4ba05dcf03b8e641c7a304f918df3134bf46c8ccf5b09d07ee283924a4cc4e9250fef582a2636bb4dac6ba71ee36662b2678dfe49d46b2
+  checksum: 127b16db2ff70a82d56e003a7c3f531f32e7e8f9e9c5f4daaa2ba55ff5494b42d1531ef1f207a1632e33ac5dc1258cb2ebc8b28eeeaa97f96ad7125b17892e7d
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-node@npm:3.55.0":
-  version: 3.55.0
-  resolution: "@aws-sdk/util-base64-node@npm:3.55.0"
+"@aws-sdk/util-base64-node@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-base64-node@npm:3.188.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.55.0
+    "@aws-sdk/util-buffer-from": 3.188.0
     tslib: ^2.3.1
-  checksum: 4a2a58ae2e5d2d904271dd0433b9c15ca9a8e9d62e979c82159420ab8e1b573e96c8f223c951be2139cdfe49a09c478d165eff9468978883c4c5bcdfa7d9fd4b
+  checksum: 0aed4d00fe893fdeddd9f6d1e2fe45a39956485f560041162f6ec4d936a64cc1e31f713980db731337316fadbbbd2241b3842bf3e15eab51c8bbc3b661720120
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-browser@npm:3.55.0":
-  version: 3.55.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.55.0"
+"@aws-sdk/util-body-length-browser@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-body-length-browser@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: f10c9e1f052da751e762e807f23b768052e5d375d7e048d596ee1d607065ff0c0ef7004bd4fd136848b6a5646c1c69e43860aa7a3da80d90023b749530faad59
+  checksum: 1b08bd1e63ec843ee336f51d894c49bf3c4c2f96e50d1711a12f7d0c5b6f7a15b490e366fec55b63e77036002994bac12927b29de2eb9ac91e4f152b1af78e58
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-node@npm:3.55.0":
-  version: 3.55.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.55.0"
+"@aws-sdk/util-body-length-node@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-body-length-node@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: 35ae66271b7160c53b344a2bd933b5882e9fcef4a47c579a2a9e313657da8b896ca6c674489767f75d148ea5ffb8cbde2127eae55f5f39aaa4823a7c1d98ec69
+  checksum: 4bb0dcc63aa616ef8efd131754882bad228d6f449faea16db38ba36d34185e45d3e7063cea4c7296609990ad77c9cd9810b66f8d9e4a08a0066d191793ceb186
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-buffer-from@npm:3.55.0":
-  version: 3.55.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.55.0"
+"@aws-sdk/util-buffer-from@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-buffer-from@npm:3.188.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.55.0
+    "@aws-sdk/is-array-buffer": 3.188.0
     tslib: ^2.3.1
-  checksum: 0c1d72cf2369c13a8bff7d990f8e8da7f5584dcbdf1965cf50674d531b42d80661eebdbbaf968d6932760fc3f5708374a676d05485a1d02347655ea5f2423f57
+  checksum: ccb9fea77e1207cfbbdd06adbba7b8128ec7f26966ff8f95743d62a760e7748c5c4ff90ad154724f8bbce12958133375e0526984a5af7ef49a98b7c6f3d7495a
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-config-provider@npm:3.109.0":
-  version: 3.109.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.109.0"
+"@aws-sdk/util-config-provider@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-config-provider@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: 99c9ef24faa555a317b46b782e211474dd9d666611e1aa76b963e93a6e7c54e32d5c20b87d9a601b9de68dfa1c7310d72667a74c335b31edb776e8494e2541af
+  checksum: 0fa44590ad6859ed0f9945b1fef62906d97ce7b5a27219e454e961d0e2d028bb9981b16ca884fc13c3c33a720228699fadd947451144a984eb7fae1ae26a2456
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-browser@npm:3.142.0":
-  version: 3.142.0
-  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.142.0"
+"@aws-sdk/util-defaults-mode-browser@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.200.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/types": 3.200.0
     bowser: ^2.11.0
     tslib: ^2.3.1
-  checksum: 6ead8f767c2dcc0e21be180784a9ca5b57daa905a426fac0d0aa12f79f026d2da55d83c8b29cbec5c6e7adaccad8219b300dc30913808770ff7a20f2aa45be15
+  checksum: 8abd66cd9b20ad6ba0c33ad69792cef4e90c5534e28b2a755d937ef06bd7ea93a89a2103a594ae7a9e01603ad941b1dd90286bc5f72701d21e9d890fe5edbd5c
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-defaults-mode-node@npm:3.142.0":
-  version: 3.142.0
-  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.142.0"
+"@aws-sdk/util-defaults-mode-node@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.200.0"
   dependencies:
-    "@aws-sdk/config-resolver": 3.130.0
-    "@aws-sdk/credential-provider-imds": 3.127.0
-    "@aws-sdk/node-config-provider": 3.127.0
-    "@aws-sdk/property-provider": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/config-resolver": 3.200.0
+    "@aws-sdk/credential-provider-imds": 3.200.0
+    "@aws-sdk/node-config-provider": 3.200.0
+    "@aws-sdk/property-provider": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 6025ea3359a16a312d1b9bdedc761f4eabd59d274bc96290514c3d8107e89da8c365db6bc23b4fb5143de5faa89ac082d435cbc655ca4457a6d9384a4bd5b643
+  checksum: 8c2ee50a266a72658d7260bd3fc03cc6717166289f2cbd538801ffb1a4d683f42fd4f81f1c465d72f6fe3169e620a2034672c1daa5793958aec45eff3f5efe5b
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-hex-encoding@npm:3.109.0":
-  version: 3.109.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.109.0"
+"@aws-sdk/util-endpoints@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/util-endpoints@npm:3.200.0"
+  dependencies:
+    "@aws-sdk/types": 3.200.0
+    tslib: ^2.3.1
+  checksum: ce1c853f7e24c2caa2ec570c45bc4141008eddc9528ddc61d2192973eb2400f1bd176637d5f00dd8302c9a30b03e1ce0a2db1cc01428744a9216bab01f69b9ed
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-hex-encoding@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-hex-encoding@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: 1c166b53d7f84c0271cb71da8ac0ef4a9bfd78f2d2d70e4a903921dd3c355a79a446fa66ff64522d87aa9c738f445fdfd527043980bea642ae3acbc7dd758edf
+  checksum: 87e79f5f124891bcdcb5347a5a566f066488da79beccbdfc39979e83d85d77fce67b22f901ab74623b172c51ad18e1d4909a610e5fff36b8c5bd16366aa4454f
   languageName: node
   linkType: hard
 
@@ -847,57 +882,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-middleware@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/util-middleware@npm:3.127.0"
+"@aws-sdk/util-middleware@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/util-middleware@npm:3.200.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: c845b1bf6339cdee9762f41c3578fafb780bf5341037d3381c4dc799ac31626031de2a80735a5edaf260da655b1ef054a950dda552aedeed4188dfe42c717e83
+  checksum: 24e6521b2fc7a6dd84eda3e4fa1820107704de8dc5e246d8fd6f1d6fc8e1d28fd74990bf3c723ea0460c4279caa13953cb8c421868e3f0987f2d3cc2851d47d5
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-uri-escape@npm:3.55.0":
-  version: 3.55.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.55.0"
+"@aws-sdk/util-uri-escape@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-uri-escape@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: fad6780856f2b42a11ce7bb1e2ea5b7a966a8f564f3d09e83dca024291ae589a0cb2a1d294812cd626346addeb292c178f84867e40f8fab6fca067bc42ad360a
+  checksum: 07f9c7d577e6f4838075a40e3f4196bae27d09474955e77b4de3031a2b3f3fa48684fd10219804490d530413ceb3386ea94f4fe5defcae66f4ad3a589560aa25
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.127.0"
+"@aws-sdk/util-user-agent-browser@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.200.0"
   dependencies:
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/types": 3.200.0
     bowser: ^2.11.0
     tslib: ^2.3.1
-  checksum: 42f08784b3f6f535516467e60897330e23b853e9ce134e9095170ef36c715aa04017b066fddf2b4830438bb00b630e7895dfcfbfaaa4d8de63d9983d9f205e25
+  checksum: dbe45ccfd76d85cf4aa4ec20a8e3747b1bf067e795dc55d665766f9c43cbfc23e78601096c0276c0272c4fbe9ff922af04a8e2b03a2c0853a6a22a3b10a8e4f2
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.127.0"
+"@aws-sdk/util-user-agent-node@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.200.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/node-config-provider": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
   peerDependencies:
     aws-crt: ">=1.0.0"
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: bba9cce7a775a3985b97960d64990d1b18ee39f0fdebcebd8d63f3eb951fe41f6808b9272ddafde2a4366f9e041bd10aec74aa8dba33d70101458dc8ce086ccf
+  checksum: 86f10cb9ba0920fd08c53c33bbe18fa95ef06afd7c54304c063d22bce06613e44b73aab9dc098abd79d384bf3ab5f62d86158d58a4efab57c095252288bcc682
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-browser@npm:3.109.0":
-  version: 3.109.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.109.0"
+"@aws-sdk/util-utf8-browser@npm:3.188.0":
+  version: 3.188.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.188.0"
   dependencies:
     tslib: ^2.3.1
-  checksum: 8311763b04261dab5995ec67abf31795f41e9c4b1ad635ed305735e14c7e3bc48e9ae349a06aab485390358a6a58e97190144ea51190983cec4ae665887b219b
+  checksum: dacd27164aa0835888434e080b67f04510e2281560540ff73496f2d0aa73b0b7f830ec08491b35c3a51bf6214615579182aff8727e151e54a74a97a197a2ac31
   languageName: node
   linkType: hard
 
@@ -910,24 +945,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-node@npm:3.109.0":
-  version: 3.109.0
-  resolution: "@aws-sdk/util-utf8-node@npm:3.109.0"
+"@aws-sdk/util-utf8-node@npm:3.199.0":
+  version: 3.199.0
+  resolution: "@aws-sdk/util-utf8-node@npm:3.199.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.55.0
+    "@aws-sdk/util-buffer-from": 3.188.0
     tslib: ^2.3.1
-  checksum: ef706db8c0ceb014bc2fb9e5045b54369160648a9e919836132f98c5537eda82193f400fab607783ecf98a5df11b66c32256c4f2780bc689d7507ddaf2a0977b
+  checksum: e18fe35d270b02ac7de34cd57e951c18613ac4553d90c85a0cd16095b138f60c36b445e1bdcd18e7d2b992b4e3536c15fe244955325c80230ddcf1145936313c
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-waiter@npm:3.127.0":
-  version: 3.127.0
-  resolution: "@aws-sdk/util-waiter@npm:3.127.0"
+"@aws-sdk/util-waiter@npm:3.200.0":
+  version: 3.200.0
+  resolution: "@aws-sdk/util-waiter@npm:3.200.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.127.0
-    "@aws-sdk/types": 3.127.0
+    "@aws-sdk/abort-controller": 3.200.0
+    "@aws-sdk/types": 3.200.0
     tslib: ^2.3.1
-  checksum: 3c27de00e943409a1fb927e450ecb7bd83cd6eb6329e0fbf51f20bd657a35571f181074f2ca1b612f87c07844be53129bf868c4acd4c734e22313197e6c70b1e
+  checksum: 1fc78cc17069d85b6152e07f90a55721615fb34fa84e0b3b8bcc56143e652361a9b9c84ad87d0e9690517cfd89c18289c575ce0eb3d9a0fe151669b285948b24
   languageName: node
   linkType: hard
 
@@ -2647,9 +2682,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:2.1198.0":
-  version: 2.1198.0
-  resolution: "aws-sdk@npm:2.1198.0"
+"aws-sdk@npm:2.1244.0":
+  version: 2.1244.0
+  resolution: "aws-sdk@npm:2.1244.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -2661,7 +2696,7 @@ __metadata:
     util: ^0.12.4
     uuid: 8.0.0
     xml2js: 0.4.19
-  checksum: d461fef39b3d3686686fc10026d6442e52bca7966613bc220131eeb3e5e3353a959ccfe52ffa31b8813e6c17f930599964873648f5eb45e7be6ef8ddb9be9d5f
+  checksum: 17aceaf86648dd25c18ca1b09a5ff76b52737e2da237755bd3c7beca78fe5d22f4047200ab39757d02af1d0f2ff557bc04c1f877a87989cac9318928a37578a6
   languageName: node
   linkType: hard
 
@@ -3590,13 +3625,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:2.2.0":
-  version: 2.2.0
-  resolution: "entities@npm:2.2.0"
-  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
-  languageName: node
-  linkType: hard
-
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -4049,12 +4077,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:3.19.0":
-  version: 3.19.0
-  resolution: "fast-xml-parser@npm:3.19.0"
+"fast-xml-parser@npm:4.0.11":
+  version: 4.0.11
+  resolution: "fast-xml-parser@npm:4.0.11"
+  dependencies:
+    strnum: ^1.0.5
   bin:
-    xml2js: cli.js
-  checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
+    fxparser: src/cli/cli.js
+  checksum: d8a08e4d5597e0fc00a86735195872eeb03008913e298830941516f3766e16ee555e2d431acc92e1dda887938edc445252ec5b59494aab60a8389888bd13719c
   languageName: node
   linkType: hard
 
@@ -7870,6 +7900,13 @@ __metadata:
   version: 3.0.0
   resolution: "strip-final-newline@npm:3.0.0"
   checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
+  languageName: node
+  linkType: hard
+
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Issue #, if available:*
Similar to https://github.com/aws-samples/aws-sdk-js-tests/pull/114

*Description of changes:*
Bumps aws-sdk deps, tested locally in Node.js and browser

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
