### PR TITLE
chore(deps-dev): bump yarn to v3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint-staged": "13.0.3",
     "prettier": "2.7.1"
   },
-  "packageManager": "yarn@3.8.1",
+  "packageManager": "yarn@3.8.3",
   "lint-staged": {
     "*.{js,css,json,md}": "prettier --write"
   }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F3.8.3

*Description of changes:*
Bumps yarn to v3.8.3

```console
$ yarn --version
! Corepack is about to download https://repo.yarnpkg.com/3.8.3/packages/yarnpkg-cli/bin/yarn.js
? Do you want to continue? [Y/n] Y

3.8.3
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
