### PR TITLE
chore(react-native): add web-streams-polyfill

### DIFF
--- a/packages/react-native/App.js
+++ b/packages/react-native/App.js
@@ -14,6 +14,7 @@ import {Colors} from 'react-native/Libraries/NewAppScreen';
 // React Native polyfills required for AWS SDK for JavaScript.
 import 'react-native-get-random-values';
 import 'react-native-url-polyfill/auto';
+import 'web-streams-polyfill/dist/polyfill';
 
 import {getV2BrowserResponse, getV3BrowserResponse} from '@aws-sdk/test-utils';
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -13,7 +13,8 @@
     "react": "^18.3.1",
     "react-native": "^0.74.3",
     "react-native-get-random-values": "^1.11.0",
-    "react-native-url-polyfill": "^2.0.0"
+    "react-native-url-polyfill": "^2.0.0",
+    "web-streams-polyfill": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,6 +553,7 @@ __metadata:
     react-native: ^0.74.3
     react-native-get-random-values: ^1.11.0
     react-native-url-polyfill: ^2.0.0
+    web-streams-polyfill: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -8005,6 +8006,13 @@ __metadata:
   dependencies:
     defaults: ^1.0.3
   checksum: 814e9d1ddcc9798f7377ffa448a5a3892232b9275ebb30a41b529607691c0491de47cba426e917a4d08ded3ee7e9ba2f3fe32e62ee3cd9c7d3bafb7754bd553c
+  languageName: node
+  linkType: hard
+
+"web-streams-polyfill@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "web-streams-polyfill@npm:4.0.0"
+  checksum: df1abcb0f811621fa3ed95491c3d281eb7c82aa898b9759e47c3c9dffe73eb65c0459433da60a76a1ea08e6158c8b33fdf3a2ea2a44b9c4c252965507d54edc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
*Issue #, if available:*
Refs: TBA

*Description of changes:*
Adds `web-streams-polyfill` so that ReadableStream is available in react-native environment

Tested with describeTable call before and after
* **Before**: Error `Property 'ReadableStream' doesn't exist` is thrown
<details>
<summary>Screenshot</summary>

<img width="561" alt="screenshot-no-polyfill" src="https://github.com/user-attachments/assets/448e525c-6431-42fd-85fb-e98a4ad3ec01">

```console
 ERROR  {
  "message": "Property 'ReadableStream' doesn't exist",
  "stack": "ReferenceError: Property 'ReadableStream' doesn't exist\n    at isStreamingPayload (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:465006:88)\n    at ?anon_0__loop3 (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:460293:85)\n    at throw (native)\n    at ?anon_0_ (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:460317:23)\n    at throw (native)\n    at asyncGeneratorStep (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:5585:19)\n    at _throw (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:5602:29)\n    at tryCallOne (/Users/distiller/react-native/sdks/hermes/build_iphonesimulator/lib/InternalBytecode/InternalBytecode.js:53:16)\n    at anonymous (/Users/distiller/react-native/sdks/hermes/build_iphonesimulator/lib/InternalBytecode/InternalBytecode.js:139:27)\n    at apply (native)\n    at anonymous (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:44439:26)\n    at _callTimer (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:44318:17)\n    at _callReactNativeMicrotasksPass (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:44363:17)\n    at callReactNativeMicrotasks (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:44569:44)\n    at __callReactNativeMicrotasks (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:2239:48)\n    at anonymous (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:2012:45)\n    at __guard (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:2211:15)\n    at flushedQueue (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:2011:21)\n    at invokeCallbackAndReturnFlushedQueue (http://localhost:8081/index.bundle//&platform=ios&dev=true&minify=false&inlineSourceMap=false&modulesOnly=false&runModule=true&app=org.reactjs.native.example.reactnative:2005:33)"
}
```

</details>

* **After**: No error thrown in <=3.574.0. The table description is printed

<details>
<summary>Screenshot</summary>

<img width="561" alt="screenshot-polyfill" src="https://github.com/user-attachments/assets/e7c70ae3-3dae-4ed1-b295-c5f5f7fbe9a8">

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
