### PR TITLE
fix(ios): define CFBundleShortVersionString

### DIFF
--- a/packages/react-native/ios/reactnative/Info.plist
+++ b/packages/react-native/ios/reactnative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>0.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws-samples/aws-sdk-js-tests/issues/219

### Description

Defines CFBundleShortVersionString requires for running ios setup

### Testing

Locally verified that app can be launched in iOS

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
