### PR TITLE
chore(react-native): bump ruby to 3.3.4

### DIFF
--- a/packages/react-native/Gemfile
+++ b/packages/react-native/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby '2.7.5'
+ruby '3.3.4'
 
 # Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
 # bound in the template on Cocoapods with next React Native release.

--- a/packages/react-native/Gemfile.lock
+++ b/packages/react-native/Gemfile.lock
@@ -100,4 +100,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.1.4
+   2.5.11

--- a/packages/react-native/Gemfile.lock
+++ b/packages/react-native/Gemfile.lock
@@ -97,7 +97,7 @@ DEPENDENCIES
   cocoapods (>= 1.13, < 1.15)
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 3.3.4p94
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws-samples/aws-sdk-js-tests/pull/216

### Description

Bumps ruby to 3.3.4 in react-native configuration

### Testing

Locally verified that AWS SDK for JavaScript makes calls on iOS

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
